### PR TITLE
fix potencial crash on ios10

### DIFF
--- a/SwiftPullToRefresh/RefreshView.swift
+++ b/SwiftPullToRefresh/RefreshView.swift
@@ -63,7 +63,10 @@ open class RefreshView: UIView {
     }
 
     open override func willMove(toSuperview newSuperview: UIView?) {
-        guard let scrollView = newSuperview as? UIScrollView else { return }
+        guard let scrollView = newSuperview as? UIScrollView, window != nil else {
+            clearObserver()
+            return
+        }
         setupObserver(scrollView)
     }
 


### PR DESCRIPTION
There will be a crash for devices on iOS10 in some cases.
Steps to reproduce:
1. TabbarController based APP
2. The viewcontroller enabled SwiftPullToRefresh is embedded as child view controller in a SomeViewController
3. SomeViewController is not the landing view controller of the tabbar controller
4. Do not tab on tabbar controller to show SomeViewController
5. Destroy the Tabbar Controller and rebuild it with the child view controllers

App will crash at step 5 with following error:
![InboxOldViewController_swift](https://user-images.githubusercontent.com/9820374/57220968-dc1a5d80-702f-11e9-8292-2018a1f226ed.png)
